### PR TITLE
run blur/preview only on files, not directories

### DIFF
--- a/binary.cjs
+++ b/binary.cjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const {mkdir, readdir, stat} = require('fs');
+const {mkdir, readdir, stat, statSync} = require('fs');
 const {join, resolve} = require('path');
 
 const ucompress = require('./cjs/index.js');
@@ -75,7 +75,7 @@ else {
   };
   if (headers && dest === source)
     ucompress.createHeaders(dest).catch(error);
-  else if (preview && dest === source)
+  else if (preview && dest === source && statSync(source).isFile())
     blur(dest).catch(error);
   else {
     const crawl = (source, dest, options) => new Promise((res, rej) => {


### PR DESCRIPTION
Hello,

when trying out ucompress (with `--preview` from the CLI) I was getting the following error:

```sh
> ucompress --preview --source _site --dest _site

/Users/christian/Documents/projects/christian-fei.github.io/node_modules/ucompress/cjs/preview.js:8
    new RegExp(`(\\${extname(source)})$`),
    ^

SyntaxError: Invalid regular expression: /(\)$/: Unterminated group
    at new RegExp (<anonymous>)
    at module.exports (/Users/christian/Documents/projects/christian-fei.github.io/node_modules/ucompress/cjs/preview.js:8:5)
    at Object.<anonymous> (/Users/christian/Documents/projects/christian-fei.github.io/node_modules/ucompress/binary.cjs:79:5)
```

The issues seems to be that the `source` var "didn't have an extension".

Cloning the repo and using the local version, I found out that it tried to run the `preview` on directories.

Added a `statSync` call with a `.isFile` check, let me know if it makes sense. Alternatively I can modify it to use an async `stat` call with callback. tests pass ofc.

Chris