### PR TITLE
special .md treatment with preview too

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Following the list of tools ued to optimized various files:
   * **jpg** or **jpeg** files via [jpegtran-bin](https://www.npmjs.com/package/jpegtran-bin) and/or [sharp](https://github.com/lovell/sharp)
   * **js** or **mjs** files via [terser](https://github.com/terser/terser) and [html-minifier](https://github.com/kangax/html-minifier)
   * **json** files are simply parsed and stringified so that white spaces get removed
+  * **md** files are transformed into their `.preview.html` version, if the _preview_ is enabled, through [marked](https://github.com/markedjs/marked)
   * **png** files via [pngquant-bin](https://www.npmjs.com/package/pngquant-bin)
   * **svg** files via [svgo](https://www.npmjs.com/package/svgo)
   * **xml** files via [html-minifier](https://www.npmjs.com/package/html-minifier)

--- a/cjs/copy.js
+++ b/cjs/copy.js
@@ -7,7 +7,6 @@ const compress = (m => m.__esModule ? /* istanbul ignore next */ m.default : /* 
 const headers = (m => m.__esModule ? /* istanbul ignore next */ m.default : /* istanbul ignore next */ m)(require('./headers.js'));
 
 compressed.add('.csv');
-compressed.add('.md');
 compressed.add('.txt');
 compressed.add('.woff2');
 compressed.add('.yml');

--- a/cjs/index.js
+++ b/cjs/index.js
@@ -11,6 +11,7 @@ const html = (m => m.__esModule ? /* istanbul ignore next */ m.default : /* ista
 const jpg = (m => m.__esModule ? /* istanbul ignore next */ m.default : /* istanbul ignore next */ m)(require('./jpg.js'));
 const js = (m => m.__esModule ? /* istanbul ignore next */ m.default : /* istanbul ignore next */ m)(require('./js.js'));
 const json = (m => m.__esModule ? /* istanbul ignore next */ m.default : /* istanbul ignore next */ m)(require('./json.js'));
+const md = (m => m.__esModule ? /* istanbul ignore next */ m.default : /* istanbul ignore next */ m)(require('./md.js'));
 const png = (m => m.__esModule ? /* istanbul ignore next */ m.default : /* istanbul ignore next */ m)(require('./png.js'));
 const svg = (m => m.__esModule ? /* istanbul ignore next */ m.default : /* istanbul ignore next */ m)(require('./svg.js'));
 const xml = (m => m.__esModule ? /* istanbul ignore next */ m.default : /* istanbul ignore next */ m)(require('./xml.js'));
@@ -71,6 +72,9 @@ const ucompress = (source, dest, options = {}) => {
     case '.json':
       method = json;
       break;
+    case '.md':
+      method = md;
+      break;
     case '.png':
       method = png;
       break;
@@ -99,6 +103,7 @@ ucompress.jpeg = jpg;
 ucompress.js = js;
 ucompress.mjs = js;
 ucompress.json = json;
+ucompress.md = md;
 ucompress.png = png;
 ucompress.svg = svg;
 ucompress.xml = xml;

--- a/cjs/md.js
+++ b/cjs/md.js
@@ -1,0 +1,98 @@
+'use strict';
+const {copyFile, readFile, writeFile} = require('fs');
+const {basename} = require('path');
+
+const html = (m => m.__esModule ? /* istanbul ignore next */ m.default : /* istanbul ignore next */ m)(require('html-minifier'));
+const marked = (m => m.__esModule ? /* istanbul ignore next */ m.default : /* istanbul ignore next */ m)(require('marked'));
+
+const compressed = (m => m.__esModule ? /* istanbul ignore next */ m.default : /* istanbul ignore next */ m)(require('./compressed.js'));
+const compress = (m => m.__esModule ? /* istanbul ignore next */ m.default : /* istanbul ignore next */ m)(require('./compress.js'));
+const htmlArgs = (m => m.__esModule ? /* istanbul ignore next */ m.default : /* istanbul ignore next */ m)(require('./html-minifier.js'));
+
+compressed.add('.md');
+
+marked.setOptions({
+  renderer: new marked.Renderer(),
+  pedantic: false,
+  gfm: true,
+  breaks: false,
+  sanitize: false,
+  smartLists: true,
+  smartypants: false,
+  xhtml: false
+});
+
+/**
+ * Copy a source file into a destination.
+ * @param {string} source The source file to copy.
+ * @param {string} dest The destination file.
+ * @param {Options} [options] Options to deal with extra computation.
+ * @return {Promise<string>} A promise that resolves with the destination file.
+ */
+module.exports = (source, dest, /* istanbul ignore next */ options = {}) =>
+  new Promise((res, rej) => {
+    const {preview} = options;
+    const onCopy = err => {
+      if (err)
+        rej(err);
+      else if (options.createFiles) {
+        compress(source, dest, 'text', options)
+            .then(() => res(dest), rej);
+      }
+      else
+        res(dest);
+    };
+    const onPreview = () => {
+      /* istanbul ignore if */
+      if (source === dest)
+        onCopy(null);
+      else
+        copyFile(source, dest, onCopy);
+    };
+    if (preview) {
+      readFile(source, (err, data) => {
+        /* istanbul ignore if */
+        if (err)
+          rej(err);
+        else {
+          marked(data.toString(), (err, md) => {
+            /* istanbul ignore if */
+            if (err)
+              rej(err);
+            else {
+              const htmlPreview = dest.replace(/\.md$/i, '.preview.html');
+              writeFile(
+                htmlPreview,
+                html.minify(
+                  `<!DOCTYPE html>
+                  <html lang="en">
+                  <head>
+                    <meta charset="UTF-8">
+                    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                    <title>Preview: ${basename(source)}</title>
+                  </head>
+                  <body>${md}</body>
+                  </html>`,
+                  htmlArgs
+                ),
+                err => {
+                  /* istanbul ignore if */
+                  if (err)
+                    rej(err);
+                  /* istanbul ignore else */
+                  else if (options.createFiles) {
+                    compress(source, htmlPreview, 'text', options)
+                      .then(() => onPreview(), rej);
+                  }
+                  else
+                    onPreview();
+                }
+              );
+            }
+          });
+        }
+      });
+    }
+    else
+      onPreview();
+  });

--- a/esm/copy.js
+++ b/esm/copy.js
@@ -6,7 +6,6 @@ import compress from './compress.js';
 import headers from './headers.js';
 
 compressed.add('.csv');
-compressed.add('.md');
 compressed.add('.txt');
 compressed.add('.woff2');
 compressed.add('.yml');

--- a/esm/index.js
+++ b/esm/index.js
@@ -10,6 +10,7 @@ import html from './html.js';
 import jpg from './jpg.js';
 import js from './js.js';
 import json from './json.js';
+import md from './md.js';
 import png from './png.js';
 import svg from './svg.js';
 import xml from './xml.js';
@@ -70,6 +71,9 @@ const ucompress = (source, dest, options = {}) => {
     case '.json':
       method = json;
       break;
+    case '.md':
+      method = md;
+      break;
     case '.png':
       method = png;
       break;
@@ -98,6 +102,7 @@ ucompress.jpeg = jpg;
 ucompress.js = js;
 ucompress.mjs = js;
 ucompress.json = json;
+ucompress.md = md;
 ucompress.png = png;
 ucompress.svg = svg;
 ucompress.xml = xml;

--- a/esm/md.js
+++ b/esm/md.js
@@ -1,0 +1,97 @@
+import {copyFile, readFile, writeFile} from 'fs';
+import {basename} from 'path';
+
+import html from 'html-minifier';
+import marked from 'marked';
+
+import compressed from './compressed.js';
+import compress from './compress.js';
+import htmlArgs from './html-minifier.js';
+
+compressed.add('.md');
+
+marked.setOptions({
+  renderer: new marked.Renderer(),
+  pedantic: false,
+  gfm: true,
+  breaks: false,
+  sanitize: false,
+  smartLists: true,
+  smartypants: false,
+  xhtml: false
+});
+
+/**
+ * Copy a source file into a destination.
+ * @param {string} source The source file to copy.
+ * @param {string} dest The destination file.
+ * @param {Options} [options] Options to deal with extra computation.
+ * @return {Promise<string>} A promise that resolves with the destination file.
+ */
+export default (source, dest, /* istanbul ignore next */ options = {}) =>
+  new Promise((res, rej) => {
+    const {preview} = options;
+    const onCopy = err => {
+      if (err)
+        rej(err);
+      else if (options.createFiles) {
+        compress(source, dest, 'text', options)
+            .then(() => res(dest), rej);
+      }
+      else
+        res(dest);
+    };
+    const onPreview = () => {
+      /* istanbul ignore if */
+      if (source === dest)
+        onCopy(null);
+      else
+        copyFile(source, dest, onCopy);
+    };
+    if (preview) {
+      readFile(source, (err, data) => {
+        /* istanbul ignore if */
+        if (err)
+          rej(err);
+        else {
+          marked(data.toString(), (err, md) => {
+            /* istanbul ignore if */
+            if (err)
+              rej(err);
+            else {
+              const htmlPreview = dest.replace(/\.md$/i, '.preview.html');
+              writeFile(
+                htmlPreview,
+                html.minify(
+                  `<!DOCTYPE html>
+                  <html lang="en">
+                  <head>
+                    <meta charset="UTF-8">
+                    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                    <title>Preview: ${basename(source)}</title>
+                  </head>
+                  <body>${md}</body>
+                  </html>`,
+                  htmlArgs
+                ),
+                err => {
+                  /* istanbul ignore if */
+                  if (err)
+                    rej(err);
+                  /* istanbul ignore else */
+                  else if (options.createFiles) {
+                    compress(source, htmlPreview, 'text', options)
+                      .then(() => onPreview(), rej);
+                  }
+                  else
+                    onPreview();
+                }
+              );
+            }
+          });
+        }
+      });
+    }
+    else
+      onPreview();
+  });

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "gifsicle": "^5.0.0",
     "html-minifier": "^4.0.0",
     "jpegtran-bin": "^4.0.0",
+    "marked": "^1.0.0",
     "mime-types": "^2.1.27",
     "minify-html-literals": "^1.3.0",
     "pngquant-bin": "^5.0.2",

--- a/test/source/test.md
+++ b/test/source/test.md
@@ -1,0 +1,9 @@
+# this is some markdown
+
+and this is its content.
+
+```js
+with (someCode) {
+  i++;
+}
+```


### PR DESCRIPTION
`--with-preview` now handles `.md` files in a special way: an _HTML_ preview of the file is created, minified, and compressed